### PR TITLE
Add ethereum.dark.florist as a route to geth.

### DIFF
--- a/mainnet-geth-lodestar-stack.yml
+++ b/mainnet-geth-lodestar-stack.yml
@@ -10,7 +10,7 @@ services:
       labels:
         - 'traefik.enable=true'
         - 'traefik.http.routers.my-geth-rpc-router.tls=true'
-        - 'traefik.http.routers.my-geth-rpc-router.rule=Host(`geth.dark.florist`) || (Host(`rpc.dark.florist`) && Path(`/winedancemuffinborrow`)) || Host(`ethereum.zoltu.io`) || Host(`ethereum.keydonix.com`)'
+        - 'traefik.http.routers.my-geth-rpc-router.rule=Host(`geth.dark.florist`) || (Host(`rpc.dark.florist`) && Path(`/winedancemuffinborrow`)) || Host(`ethereum.dark.florist`) || Host(`ethereum.zoltu.io`) || Host(`ethereum.keydonix.com`)'
         - 'traefik.http.routers.my-geth-rpc-router.service=my-geth-rpc-service'
         - 'traefik.http.services.my-geth-rpc-service.loadbalancer.server.port=8545'
     logging:


### PR DESCRIPTION
When we just want an RPC server but we don't care about the client backing it, we should use `https://ethereum.dark.florist`.  In the future this can be redirected to point at whatever we want instead of being bound to a specific implementation.