### PR TITLE
Attempt to fix Nethermind permissions.

### DIFF
--- a/sepolia-nethermind-lodestar-stack.yml
+++ b/sepolia-nethermind-lodestar-stack.yml
@@ -22,8 +22,6 @@ services:
     image: 'nethermind/nethermind:1.31.4-chiseled@sha256:2822ce09240bed0c277df588c47826e6d531ad88e109e99797f54db0243f63a5'
     environment:
       NETHERMIND_CONFIG: 'sepolia'
-      NETHERMIND_INITCONFIG_BASEDBPATH: '/data/db'
-      NETHERMIND_KEYSTORECONFIG_KEYSTOREDIRECTORY: '/data/keystore'
       NETHERMIND_HEALTHCHECKSCONFIG_ENABLED: 'true'
       NETHERMIND_HEALTHCHECKSCONFIG_UIENABLED: 'true'
       NETHERMIND_INITCONFIG_MEMORYHINT: '24000000000'
@@ -60,7 +58,13 @@ services:
     volumes:
       - type: 'volume'
         source: 'nethermind-data'
-        target: '/data'
+        target: '/nethermind/nethermind_db'
+      - type: 'volume'
+        source: 'nethermind-keystore'
+        target: '/nethermind/keystore'
+      - type: 'volume'
+        source: 'nethermind-logs'
+        target: '/nethermind/logs'
 
   lodestar:
     deploy:
@@ -123,4 +127,6 @@ networks:
 
 volumes:
   nethermind-data:
+  netehrmind-log:
+  nethermind-keystore:
   lodestar-data:


### PR DESCRIPTION
The Nethermind chiseled dockerfile uses a non-root user and it sets up some very specific paths with proper permissions.  We were ignoring the default paths with permissions setup and using our own (so we could have a single volume) but this breaks the permission setup.  Docker, sadly, doesn't have a way to fix this at runtime without manual intervention, so this change switches to using Nethermind supplied paths.